### PR TITLE
Propose Raycast Hotkey config

### DIFF
--- a/nice_to_have/raycast.md
+++ b/nice_to_have/raycast.md
@@ -9,3 +9,7 @@ Install the recommended extensions:
 - List Repos (Quickly open your local git repositories)
 - Brew (List and manage your Homebrew packages)
 - Emoji Picker (Quickly insert emojis into your text)
+
+Update the default hotkey:
+- Go to Raycast Preferences `CMD + ,`
+- Set Raycast Hotkey from `ALT + SPACE` to `CMD + SPACE`


### PR DESCRIPTION
It does not make sense to have both raycast and spotlight active. Raycast is enabled by default via `Alt + Space`.